### PR TITLE
Use `update_state_before_display!` instead of a fake display

### DIFF
--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -21,7 +21,7 @@ function create_plot(x_data, y_data, x_name, y_name; art=Scatter)
     fig = Figure(size = (800, 600))
     ax = Axis(fig[1, 1], xlabel=x_name, ylabel=y_name, title="$(var_to_string(art)) Plot of $y_name vs $x_name")
     draw!(ax, plt)
-    show(IOBuffer(), MIME"text/html"(), fig) # Force render to complete without needing a display
+    Makie.update_state_before_display!(fig) # Force render to complete without needing a display
     global cp_figure = fig
     global cp_figure_ax = ax
     return fig


### PR DESCRIPTION
This was an online PR, I haven't tested it locally but it probably does what you want it to do.  The full show is a bit less efficient than invoking this function, which will force axis limits etc. to be set.